### PR TITLE
Select: Clear timeout on destroy()

### DIFF
--- a/src/widgets/select.js
+++ b/src/widgets/select.js
@@ -377,6 +377,10 @@ export class Select extends Button {
   }
 
   destroy() {
+    if (this.__timeout !== false) {
+      window.clearTimeout(this.__timeout);
+      this.__timeout = false;
+    }
     this.clear();
     this._list.remove();
     document.removeEventListener('touchstart', this._globalTouchStart);


### PR DESCRIPTION
When destroying an aux-select element with an open list, once the timeout fires it will cause a null access in widget.js:841 as this.options got set to `null` by destroy()